### PR TITLE
Fix `environment` option to work with multicontainer updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,4 @@ services:
       - redis
     privileged: true
     environment:
-      - WPE_URL: http://web:5000/
+      WPE_URL: http://web:5000/


### PR DESCRIPTION
Environment needs to be of type `string[]` or `{ [key: envVarName]: string }`.